### PR TITLE
SP-329 | fix bad indexing parameters and fixes in error escape

### DIFF
--- a/doofinder/doofinder.php
+++ b/doofinder/doofinder.php
@@ -3,7 +3,7 @@
  * Plugin Name: Doofinder
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 0.4.5
+ * Version: 0.4.6
  * Author: Doofinder
  * Description: Integrate Doofinder Search in your WordPress website.
  *
@@ -30,7 +30,7 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ):
 		 *
 		 * @var string
 		 */
-		public static $version = '0.4.5';
+		public static $version = '0.4.6';
 
 		/**
 		 * The only instance of Doofinder_For_WordPress

--- a/doofinder/includes/api/class-doofinder-api.php
+++ b/doofinder/includes/api/class-doofinder-api.php
@@ -333,6 +333,8 @@ class Doofinder_Api implements Api_Wrapper {
 		$this->log->log( 'Send batch - items type: "' . $items_type . '"' );
 		$this->log->log( 'Send batch - language: "' . $language . '"' );
 
+		$items_type = str_replace('-', '_', $items_type);
+		$this->log->log( 'Send batch - items type modified to comply with validations: "' . $items_type . '"' );
 		// Doofinder API will throw an exception in case of invalid token
 		// or something like that.
 
@@ -399,6 +401,12 @@ class Doofinder_Api implements Api_Wrapper {
 						$this->log->log( 'Send batch - Real Index NOT Created' . "\n" );
 						$this->log->log( get_class( $exception ) );
 						$this->log->log( $exception->getMessage() );
+
+						$this->log->log( 'Reset post_type data to start indexing in a clean environment ' );
+						$indexing_data->set( 'post_type', '');
+			
+						$this->log->log( 'Empty temporal index to start indexing in a clean environment ' );
+						$indexing_data->set( 'temp_index', [], true );
 
 						if ( $exception instanceof DoofinderError ) {
 							$this->log->log( $exception->getBody() );
@@ -649,6 +657,12 @@ class Doofinder_Api implements Api_Wrapper {
 			$this->log->log( 'Replace Index - Exception' . "\n" );
 			$this->log->log( get_class( $exception ) );
 			$this->log->log( $exception->getMessage() );
+
+			$this->log->log( 'Reset post_type data to start indexing in a clean environment ' );
+			$indexing_data->set( 'post_type', '');
+
+			$this->log->log( 'Empty temporal index to start indexing in a clean environment ' );
+			$indexing_data->set( 'temp_index', [], true );
 
 			if ( $exception instanceof DoofinderError ) {
 				$this->log->log( $exception->getBody() );

--- a/doofinder/includes/class-data-index.php
+++ b/doofinder/includes/class-data-index.php
@@ -251,8 +251,9 @@ class Data_Index {
 		$this->post_types = $post_types->get_indexable();
 
 		// if we start indexing, then post type is not set, so we get first post type from list
+		// Replace invalid characters with valid ones
 		if ( ! $this->indexing_data->get( 'post_type' ) ) {
-			$this->indexing_data->set( 'post_type', $this->post_types[0] );
+			$this->indexing_data->set( 'post_type', str_replace('-', '_', $this->post_types[0]) );
 		}
 	}
 
@@ -630,8 +631,8 @@ class Data_Index {
 			$this->log->log( 'Call Replace Index  - Get API Client Instance' );
 			$this->api = Api_Factory::get( $language );
 		}
-
-		$post_type = $this->indexing_data->get( 'post_type' );
+		// Replace invalid characters with valid ones
+		$post_type = str_replace('-', '_', $this->indexing_data->get( 'post_type' ));
 
 		$api_response = $this->api->replace_index( $post_type );
 

--- a/doofinder/readme.txt
+++ b/doofinder/readme.txt
@@ -1,7 +1,7 @@
 === Doofinder ===
 Contributors: doofinder, chopchoporg
 Tags: search, autocomplete
-Version: 0.4.5
+Version: 0.4.6
 Requires at least: 4.1
 Tested up to: 5.9
 Stable tag: trunk
@@ -113,6 +113,9 @@ Just send your questions to <mailto:support@doofinder.com> and we will try to an
 
 
 == Changelog ==
+
+= 0.4.6 =
+- Fix bad indexing parameters and fixes in error escape
 
 = 0.4.5 =
 - Fix scape in API HOST

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-wordpress",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Integrate Doofinder in your WordPress site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
An error occurs when trying to index a porst_type containing spaces. Worspress automatically saves them with a ' - ' symbol.
For example: "My Posts" is stored as my-posts
The doofAPI format would be my_posts.
I have replaced the string and it would work for all the types you try to index.

Another problem is that the error escaping was not complete, so even if it failed the data would remain saved and it would always try to index the same thing. That's why even if you changed the types in the settings it kept indexing the same ones. This has also been solved.