### PR TITLE
add portfolio categories to the feed indexation

### DIFF
--- a/doofinder/doofinder.php
+++ b/doofinder/doofinder.php
@@ -3,7 +3,7 @@
  * Plugin Name: Doofinder
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
- * Version: 0.4.8
+ * Version: 0.4.9
  * Author: Doofinder
  * Description: Integrate Doofinder Search in your WordPress website.
  *
@@ -30,7 +30,7 @@ if ( ! class_exists( '\Doofinder\WP\Doofinder_For_WordPress' ) ):
 		 *
 		 * @var string
 		 */
-		public static $version = '0.4.8';
+		public static $version = '0.4.9';
 
 		/**
 		 * The only instance of Doofinder_For_WordPress

--- a/doofinder/includes/class-post.php
+++ b/doofinder/includes/class-post.php
@@ -348,11 +348,13 @@ class Post {
 	 */
 	private function get_categories() {
 		$all_categories = get_categories();
-		$all_portf_categories = get_terms('portfolio_category');
+		$try_portfolio_cat = get_terms('portfolio_category');
+		$all_portf_categories = (is_wp_error($try_portfolio_cat) ? [] : $try_portfolio_cat);
 		$all_categories = array_merge($all_categories, $all_portf_categories);
 		
 		$post_categories = wp_get_post_categories($this->post->ID, array('fields' => 'all'));
-		$post_portf_categories = wp_get_object_terms($this->post->ID, 'portfolio_category', array('fields' => 'all'));
+		$try_portfolio_cat = wp_get_object_terms($this->post->ID, 'portfolio_category', array('fields' => 'all'));
+		$post_portf_categories = (is_wp_error($try_portfolio_cat) ? [] : $try_portfolio_cat);
 		$all_post_categories = array_merge($post_categories, $post_portf_categories);
 
 		$formatted_categories = array();

--- a/doofinder/includes/class-post.php
+++ b/doofinder/includes/class-post.php
@@ -348,14 +348,12 @@ class Post {
 	 */
 	private function get_categories() {
 		$all_categories = get_categories();
-		$try_portfolio_cat = get_terms('portfolio_category');
-		$all_portf_categories = (is_wp_error($try_portfolio_cat) ? [] : $try_portfolio_cat);
-		$all_categories = array_merge($all_categories, $all_portf_categories);
-		
 		$post_categories = wp_get_post_categories($this->post->ID, array('fields' => 'all'));
-		$try_portfolio_cat = wp_get_object_terms($this->post->ID, 'portfolio_category', array('fields' => 'all'));
-		$post_portf_categories = (is_wp_error($try_portfolio_cat) ? [] : $try_portfolio_cat);
-		$all_post_categories = array_merge($post_categories, $post_portf_categories);
+
+		if(taxonomy_exists("portfolio_category")){
+			$all_categories = array_merge($all_categories, get_terms('portfolio_category'));
+			$post_categories = array_merge($post_categories, wp_get_object_terms($this->post->ID, 'portfolio_category', array('fields' => 'all')));
+		}
 
 		$formatted_categories = array();
 
@@ -368,7 +366,7 @@ class Post {
 			$categories[ $term->term_id ] = $term;
 		}
 
-		foreach ( $all_post_categories as $category ) {
+		foreach ( $post_categories as $category ) {
 			$formatted_categories[] = join(
 				' > ',
 				array_reverse( $this->get_category_full_path(

--- a/doofinder/includes/class-post.php
+++ b/doofinder/includes/class-post.php
@@ -320,7 +320,7 @@ class Post {
 		}
 
 		// Add categories.
-		if ( Settings::get_index_categories() ) {
+		if ( Settings::get_index_categories() ) {		
 			$data['categories'] = $this->get_categories();
 		}
 
@@ -347,8 +347,14 @@ class Post {
 	 * @return string[]
 	 */
 	private function get_categories() {
-		$all_categories       = get_categories();
-		$post_categories      = wp_get_post_categories( $this->post->ID, array( 'fields' => 'all' ) );
+		$all_categories = get_categories();
+		$all_portf_categories = get_terms('portfolio_category');
+		$all_categories = array_merge($all_categories, $all_portf_categories);
+		
+		$post_categories = wp_get_post_categories($this->post->ID, array('fields' => 'all'));
+		$post_portf_categories = wp_get_object_terms($this->post->ID, 'portfolio_category', array('fields' => 'all'));
+		$all_post_categories = array_merge($post_categories, $post_portf_categories);
+
 		$formatted_categories = array();
 
 		// We have categories as a regular array. Remap to associative
@@ -360,7 +366,7 @@ class Post {
 			$categories[ $term->term_id ] = $term;
 		}
 
-		foreach ( $post_categories as $category ) {
+		foreach ( $all_post_categories as $category ) {
 			$formatted_categories[] = join(
 				' > ',
 				array_reverse( $this->get_category_full_path(

--- a/doofinder/readme.txt
+++ b/doofinder/readme.txt
@@ -1,7 +1,7 @@
 === Doofinder ===
 Contributors: doofinder, chopchoporg
 Tags: search, autocomplete
-Version: 0.4.8
+Version: 0.4.9
 Requires at least: 4.1
 Tested up to: 5.9
 Stable tag: trunk
@@ -113,6 +113,8 @@ Just send your questions to <mailto:support@doofinder.com> and we will try to an
 
 
 == Changelog ==
+= 0.4.9 =
+- Added portfolio_categories to the feed indexation
 
 = 0.4.8 =
 - Add excerpt field for any indexable post types.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-wordpress",
-  "version": "0.4.7",
+  "version": "0.4.9",
   "description": "Integrate Doofinder in your WordPress site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Ticket: https://doofinder.freshdesk.com/a/tickets/71479
The feed indexation wasn't taking the portfolio_categories, I've modified the plugin to include those categories but I'm not sure if it is the way to do it in wordpress, how do you see it @eduardogomez97 and @pedromcp90?