### PR TITLE
Reset post id on exception

### DIFF
--- a/doofinder/includes/api/class-doofinder-api.php
+++ b/doofinder/includes/api/class-doofinder-api.php
@@ -407,6 +407,9 @@ class Doofinder_Api implements Api_Wrapper {
 			
 						$this->log->log( 'Empty temporal index to start indexing in a clean environment ' );
 						$indexing_data->set( 'temp_index', [], true );
+ 
+                        $this->log->log( 'Reset post id to begin with 0 ' );
+                        $indexing_data->set( 'post_id', 0, true);
 
 						if ( $exception instanceof DoofinderError ) {
 							$this->log->log( $exception->getBody() );
@@ -488,9 +491,14 @@ class Doofinder_Api implements Api_Wrapper {
 			$this->log->log( get_class( $exception ) );
 			$this->log->log( $exception->getMessage() );
 
+            $this->log->log( 'Reset post_type data to start indexing in a clean environment ' );
+			$indexing_data->set( 'post_type', '');
+
 			$this->log->log( 'Empty temporal index when an error occurs. This way the next one does not crash. ' );
 			$indexing_data->set( 'temp_index', [], true );
-			$this->log->log($indexing_data->get( 'temp_index' ));
+
+            $this->log->log( 'Reset post id to begin with 0 ' );
+            $indexing_data->set( 'post_id', 0, true);
 
 			if ( $exception instanceof DoofinderError ) {
 				$this->log->log( $exception->getBody() );
@@ -663,6 +671,9 @@ class Doofinder_Api implements Api_Wrapper {
 
 			$this->log->log( 'Empty temporal index to start indexing in a clean environment ' );
 			$indexing_data->set( 'temp_index', [], true );
+            
+			$this->log->log( 'Reset post id to begin with 0 ' );
+            $indexing_data->set( 'post_id', 0, true);
 
 			$this->log->log( 'Post id:  ' . $indexing_data->get( 'post_id' ));
 			$this->log->log( 'Reset post id to start indexing in a clean environment ' );

--- a/doofinder/includes/class-data-index.php
+++ b/doofinder/includes/class-data-index.php
@@ -122,6 +122,7 @@ class Data_Index {
 	}
 
 	public function ajax_handler() {
+        $this->log->log( $this->indexing_data->get( 'temp_index' ));
 		$status = $this->indexing_data->get( 'status' );
 
 		// If the indexing has been completed we are reindexing.
@@ -641,6 +642,10 @@ class Data_Index {
 		if ( $api_response !== Api_Status::$success ) {
 
 			$message = __( "Replacing Index \"$post_type\" with temporary one.", 'woocommerce-doofinder' );
+
+            $this->log->log( 'Setting status to completed' );
+            $this->indexing_data->set( 'status', 'completed' );
+			$this->indexing_data->set( 'post_id', 0);
 
 			// if ( $sent_to_api === Api_Status::$indexing_in_progress ) {
 			// 	$message = __( "Deleting \"$post_type\" type...", 'woocommerce-doofinder' );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doofinder-wordpress",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Integrate Doofinder in your WordPress site with (almost) no effort.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Whenever an exception happens, the post_id index is not restored and this makes that every indexation in the future fails